### PR TITLE
Fixed a bug where wrong body was sent in token requests

### DIFF
--- a/src/Nmrkt/GuzzleOAuth2/GrantType/AuthorizationCode.php
+++ b/src/Nmrkt/GuzzleOAuth2/GrantType/AuthorizationCode.php
@@ -62,7 +62,7 @@ class AuthorizationCode implements GrantTypeInterface
         }
 
         $request = $this->client->createRequest('POST', null);
-        $request->setBody(Utils::arrayToPostBody($this->config));
+        $request->setBody(Utils::arrayToPostBody(new Collection($postBody)));
         $clientCredentialsSigner->sign(
             $request, 
             $this->config['client_id'], 

--- a/src/Nmrkt/GuzzleOAuth2/GrantType/PasswordCredentials.php
+++ b/src/Nmrkt/GuzzleOAuth2/GrantType/PasswordCredentials.php
@@ -59,7 +59,7 @@ class PasswordCredentials implements GrantTypeInterface
         }
 
         $request = $this->client->createRequest('POST', null);
-        $request->setBody(Utils::arrayToPostBody($this->config));
+        $request->setBody(Utils::arrayToPostBody(new Collection($postBody)));
         $clientCredentialsSigner->sign(
             $request, 
             $this->config['client_id'], 

--- a/src/Nmrkt/GuzzleOAuth2/GrantType/RefreshToken.php
+++ b/src/Nmrkt/GuzzleOAuth2/GrantType/RefreshToken.php
@@ -59,7 +59,7 @@ class RefreshToken implements GrantTypeInterface
         }
         
         $request = $this->client->createRequest('POST', null);
-        $request->setBody(Utils::arrayToPostBody($this->config));
+        $request->setBody(Utils::arrayToPostBody(new Collection($postBody)));
         $clientCredentialsSigner->sign(
             $request, 
             $this->config['client_id'], 


### PR DESCRIPTION
The wrong request body was sent for some grant types:

* AuthorizationCode
* PasswordCredentials
* RefreshToken

The configuration was sent instead of the purposely built post body. As the Utils::arrayToPostBody() doesn't take a primitive array it was wrapped in the Collection class.